### PR TITLE
Revert "Merge pull request #6 from ARMmbed/offir-blockdevice-example"

### DIFF
--- a/spif-driver.lib
+++ b/spif-driver.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/spif-driver/#2fc4f8e5395cda750484a7a59db95544a2e85bf8
+https://github.com/ARMmbed/spif-driver/#e5e6616914a23fb11a5ae8b5c9cbfb8a600c64b2


### PR DESCRIPTION
This reverts commit 2e0ceed24750391b8fbcf73dc1d05c2e3f0dbf9b, reversing
changes made to aad528497c95196d62c4f2361b659bf1e5536028.

Referenced PR does not work when compiled with IAR and ARM compilers.
Blocking Mbed OS PRs in CI.