### PR TITLE
Updating mbed-os to mbed-os-5.12.0-rc2

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5eabfabc51e10eec9a523e749ce207b74a8a5f64
+https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.12.0-rc2 . 