### PR TITLE
Updating mbed-os to mbed-os-5.12.1

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#6bf7fd3ecc601b2b1cf76a198ec55c06815d64c6
+https://github.com/ARMmbed/mbed-os/#0063e5de32fc575f061244c96ac60c41c07bd2e6


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.12.1 . 