### PR TITLE
Updating mbed-os to mbed-os-5.13.4

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing to Mbed OS
+
+Mbed OS is an open-source, device software platform for the Internet of Things. Contributions are an important part of the platform, and our goal is to make it as simple as possible to become a contributor.
+
+To encourage productive collaboration, as well as robust, consistent and maintainable code, we have a set of guidelines for [contributing to Mbed OS](https://os.mbed.com/docs/mbed-os/latest/contributing/index.html).

--- a/README.md
+++ b/README.md
@@ -325,4 +325,10 @@ Serial pc(TX, RX);
 
 pc.printf("...");    // Replace printf with pc.printf in the example
 ```
+## License and contributions
+
+The software is provided under Apache-2.0 license. Contributions to this project are accepted under the same license. Please see [contributing.md](CONTRIBUTING.md) for more info.
+
+This project contains code from other projects. The original license text is included in those source files. They must comply with our license guide.
+
 

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#46404419007e1a0ab844995b44ac93bb1002c872
+https://github.com/ARMmbed/mbed-os/#b6e5a0a8afa34dec9dae8963778aebce0c82a54b

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5eabfabc51e10eec9a523e749ce207b74a8a5f64
+https://github.com/ARMmbed/mbed-os/#46404419007e1a0ab844995b44ac93bb1002c872

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,12 @@
+# Testing examples
+
+Examples are tested using tool [htrun](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-host-tests) and templated print log. 
+
+To run the test, use following command after you build the example:
+```
+mbedhtrun -d D: -p COM4 -m K64F -f .\BUILD\K64F\GCC_ARM\blockdevice.bin --compare-log tests\blockdevice.log
+```
+
+
+More details about `htrun` are [here](https://github.com/ARMmbed/htrun#testing-mbed-os-examples).
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,5 +8,5 @@ mbedhtrun -d D: -p COM4 -m K64F -f .\BUILD\K64F\GCC_ARM\blockdevice.bin --compar
 ```
 
 
-More details about `htrun` are [here](https://github.com/ARMmbed/htrun#testing-mbed-os-examples).
+More details about `htrun` are [here](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-host-tests#testing-mbed-os-examples).
 

--- a/tests/blockdevice.log
+++ b/tests/blockdevice.log
@@ -1,0 +1,19 @@
+--- Mbed OS block device example ---
+bd.init\(\)
+bd.init -> 0
+--- Block device geometry ---
+read_size:
+program_size:
+erase_size:
+size:
+---
+bd.read
+--- Stored data ---
+---
+bd.erase
+bd.program
+bd.read
+---
+bd.deinit\(\)
+bd.deinit -> 0
+--- done! ---

--- a/tests/blockdevice.log
+++ b/tests/blockdevice.log
@@ -2,17 +2,24 @@
 bd.init\(\)
 bd.init -> 0
 --- Block device geometry ---
-read_size:
-program_size:
-erase_size:
-size:
+read_size:\s+\d+ B
+program_size:\s+\d+ B
+erase_size:\s+\d+ B
+size:\s+\d+ B
 ---
-bd.read
+bd.read\((0x)?[0-9a-fA-F]+, \d+, \d+\)
+bd.read -> 0
 --- Stored data ---
+([0-9a-fA-F]{2}\s+){15}[0-9a-fA-F]{2}
 ---
-bd.erase
-bd.program
-bd.read
+bd.erase\(\d+, \d+\)
+bd.erase -> 0
+bd.program\((0x)?[0-9a-fA-F]+, \d+, \d+\)
+bd.program -> 0
+bd.read\((0x)?[0-9a-fA-F]+, \d+, \d+\)
+bd.read -> 0
+--- Stored data ---
+([0-9a-fA-F]{2}\s+){15}[0-9a-fA-F]{2}
 ---
 bd.deinit\(\)
 bd.deinit -> 0


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.13.4 . 