### PR TITLE
Update for mbed-os-6.2.0

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a6207cadad0acd1876f436dc6baeddf46c42af06
+https://github.com/ARMmbed/mbed-os/#a2ada74770f043aff3e61e29d164a8e78274fcd4


### PR DESCRIPTION
This pull request updates the example to be compatible with the 
mbed-os-6.2.0 release of mbed-os. 