### PR TITLE
CMake: Add CMake support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,19 @@
+# Copyright (c) 2020 Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the License); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 language: python sh
 os: linux
 dist: xenial
@@ -79,6 +95,7 @@ matrix:
 
     - &build-test
       stage: "Mbed CLI Build"
+      name: "Mbed CLI blockdevice example - develop (K64F)"
       language: python
       python: 3.8
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
+language: python sh
+os: linux
+dist: xenial
 
 env:
-  matrix:
-   
   global:
     - >
       STATUS=$'curl -so/dev/null --user $MBED_BOT --request POST
@@ -12,49 +13,110 @@ env:
       "context": "travis-ci/$TARGET",
       "target_url": "https://travis-ci.org/$TRAVIS_REPO_SLUG/jobs/$TRAVIS_JOB_ID"
       }\nDATA'
+    - PROFILE=develop
+
 
 cache:
   pip: true
+  ccache: true
+  # It looks like ccache for arm-none-eabi is not yet supported by Travis.
+  # Therefore manually adding ccache directory to cache
   directories:
-    - $HOME/.cache/apt
+    - ${HOME}/.ccache
 
-before_install:
-  - bash -c "$STATUS" pending "Build $TARGET in progress"
-  # Make sure pipefail
-  - set -o pipefail
-  # Setup apt to cache
-  - mkdir -p $HOME/.cache/apt/partial
-  - sudo rm -rf /var/cache/apt/archives
-  - sudo ln -s $HOME/.cache/apt /var/cache/apt/archives
-  # Setup ppa to make sure arm-none-eabi-gcc is correct version
-  - sudo add-apt-repository -y ppa:team-gcc-arm-embedded/ppa
-  - sudo apt-get update -qq
+matrix:
+  include:
 
-after_success:
-  - bash -c "$STATUS" success "Build $TARGET has passed"
+    - &cmake-build-test
+      stage: "CMake"
+      name: "CMake blockdevice example - develop (K64F)"
+      env: NAME=cmake_test TARGET_NAME=K64F PROFILE=develop  CACHE_NAME=develop-K64F
+      language: python
+      python: 3.8
+      addons:
+        apt:
+          sources:
+            - sourceline: 'deb https://apt.kitware.com/ubuntu/ xenial main'
+              key_url: 'https://apt.kitware.com/keys/kitware-archive-latest.asc'
+            - sourceline: 'deb https://apt.kitware.com/ubuntu/ xenial-rc main'
+          packages:
+            - cmake
+            - ninja-build
+      install:
+        # Setup ccache
+        - ccache -o compiler_check=content
+        - ccache -M 1G
+        - pushd /usr/lib/ccache
+        - sudo ln -s ../../bin/ccache arm-none-eabi-gcc
+        - sudo ln -s ../../bin/ccache arm-none-eabi-g++
+        - export PATH="/usr/lib/ccache:$PATH"
+        - popd
+        # Install arm-none-eabi-gcc
+        - pushd /home/travis/build && mkdir arm-gcc && cd arm-gcc
+        - curl -L0 "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2?revision=05382cca-1721-44e1-ae19-1e7c3dc96118&la=en&hash=D7C9D18FCA2DD9F894FD9F3C3DC9228498FA281A" --output gcc-arm-none-eabi-9-2020-q2-update.tar.bz2
+        - tar xf gcc-arm-none-eabi-9-2020-q2-update.tar.bz2
+        - export PATH="$PATH:${PWD}/gcc-arm-none-eabi-9-2020-q2-update/bin"
+        - popd
+        - arm-none-eabi-gcc --version
+        # Hide Travis-preinstalled CMake
+        # The Travis-preinstalled CMake is unfortunately not installed via apt, so we
+        # can't replace it with an apt-supplied version very easily. Additionally, we
+        # can't permit the Travis-preinstalled copy to survive, as the Travis default
+        # path lists the Travis CMake install location ahead of any place where apt
+        # would install CMake to. Instead of apt removing or upgrading to a new CMake
+        # version, we must instead delete the Travis copy of CMake.
+        - sudo rm -rf /usr/local/cmake*
+        - pip install --upgrade mbed-tools
+        - pip install prettytable==0.7.2
+        - pip install future==0.16.0
+        - pip install "Jinja2>=2.10.1,<2.11"
+        - pip install "intelhex>=1.3,<=2.2.1"
+      script:
+        - mbedtools checkout
+        - echo mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - ccache -s
 
-after_failure:
-  - bash -c "$STATUS" failure "Build $TARGET has failed"
+    - &build-test
+      stage: "Mbed CLI Build"
+      language: python
+      python: 3.8
+      install:
+        # Setup ccache
+        - ccache -o compiler_check=content
+        - ccache -M 1G
+        - pushd /usr/lib/ccache
+        - sudo ln -s ../../bin/ccache arm-none-eabi-gcc
+        - sudo ln -s ../../bin/ccache arm-none-eabi-g++
+        - export PATH="/usr/lib/ccache:$PATH"
+        - popd
+        # Install arm-none-eabi-gcc
+        - pushd /home/travis/build && mkdir arm-gcc && cd arm-gcc
+        - curl -L0 "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2?revision=05382cca-1721-44e1-ae19-1e7c3dc96118&la=en&hash=D7C9D18FCA2DD9F894FD9F3C3DC9228498FA281A" --output gcc-arm-none-eabi-9-2020-q2-update.tar.bz2
+        - tar xf gcc-arm-none-eabi-9-2020-q2-update.tar.bz2
+        - export PATH="$PATH:${PWD}/gcc-arm-none-eabi-9-2020-q2-update/bin"
+        - popd
+        - arm-none-eabi-gcc --version
+        # Deploy mbed and pip dependencies
+        - pip install mbed-cli
+        - mbed deploy --verbose
+        - pip install -r mbed-os/requirements.txt
+      script:
+        # Check that example compiles with sd
+        - mbed compile -t GCC_ARM -m K64F -j0
 
-install:
-  # Install dependencies
-  - sudo apt-get install gcc-arm-embedded
-  - pip install --user mbed-cli
-  # Deploy mbed and pip dependencies
-  - mbed deploy
-  - pip install --user -r mbed-os/requirements.txt
-  # Print versions we use
-  - arm-none-eabi-gcc --version
-  - gcc --version
-  - python --version
+        # Check that example compiles with spif
+        - sed -i 's/SDBlockDevice bd/SPIFBlockDevice bd/g' main.cpp
+        - sed -i 's/MBED_CONF_SD/MBED_CONF_SPIF_DRIVER/g' main.cpp
+        - mbed compile -t GCC_ARM -m K82F -j0
 
-script:
-  # Check that example compiles with sd
-  - mbed compile -t GCC_ARM -m K64F -j0
+    - <<: *build-test
 
-  # Check that example compiles with spif
-  - sed -i 's/SDBlockDevice bd/SPIFBlockDevice bd/g' main.cpp
-  - sed -i 's/MBED_CONF_SD/MBED_CONF_SPIF_DRIVER/g' main.cpp
-  - mbed compile -t GCC_ARM -m $K82F -j0
+    - <<: *cmake-build-test
+      name: "CMake blockdevice example - release (K64F)"
+      env: NAME=cmake_test TARGET_NAME=K64F PROFILE=release CACHE_NAME=release-K64F
 
+    - <<: *cmake-build-test
+      name: "CMake blockdevice example - debug (K64F)"
+      env: NAME=cmake_test TARGET_NAME=K64F PROFILE=debug CACHE_NAME=debug-K64F
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,41 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
+set(MBED_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/.mbedbuild CACHE INTERNAL "")
+set(APP_TARGET mbed-os-example-blockdevice)
+
+include(${MBED_PATH}/tools/cmake/app.cmake)
+
+add_subdirectory(${MBED_PATH})
+
+add_executable(${APP_TARGET})
+
+mbed_configure_app_target(${APP_TARGET})
+
+mbed_set_mbed_target_linker_script(${APP_TARGET})
+
+project(${APP_TARGET})
+
+target_sources(${APP_TARGET}
+    PRIVATE
+        main.cpp
+)
+
+target_link_libraries(${APP_TARGET}
+    PRIVATE
+        mbed-os
+        mbed-events
+        mbed-storage
+        mbed-storage-qspif
+        mbed-storage-flashiap
+)
+
+mbed_set_post_build(${APP_TARGET})
+
+option(VERBOSE_BUILD "Have a verbose build process")
+if(VERBOSE_BUILD)
+    set(CMAKE_VERBOSE_MAKEFILE ON)
+endif()

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#f2278567d09b9ae9f4843e1d9d393526b9462783
+https://github.com/ARMmbed/mbed-os/


### PR DESCRIPTION
- Added CMakeLists.txt file to blockdevice example so that it can build via CMake
- Update mbed-os.lib to latest master to pick CMake changes
- Add CMake test and update Mbed CLI build test in `.travis.yml`

@0xc0170 @hugueskamba