### PR TITLE
Improve explanation for adding a new block device

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,9 +88,9 @@ matrix:
         - pip install "Jinja2>=2.10.1,<2.11"
         - pip install "intelhex>=1.3,<=2.2.1"
       script:
-        - mbedtools checkout
-        - echo mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
-        - mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - mbedtools deploy
+        - echo mbedtools compile -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - mbedtools compile -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
         - ccache -s
 
     - &build-test


### PR DESCRIPTION
## Summary of Changes

Updated README to reflect the current procedure for adding a block device. Replaced extraneous information regarding types of block devices supported by Mbed OS with link to corresponding page on Mbed OS documentation website. Fixed mbedtools invocation in travis script which was breaking CI.