### PR TITLE
CMake: Include only the libraries required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,9 +88,9 @@ matrix:
         - pip install "Jinja2>=2.10.1,<2.11"
         - pip install "intelhex>=1.3,<=2.2.1"
       script:
-        - mbedtools checkout
-        - echo mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
-        - mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - mbedtools deploy
+        - echo mbedtools compile -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - mbedtools compile -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
         - ccache -s
 
     - &build-test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,36 @@ target_sources(${APP_TARGET}
         main.cpp
 )
 
+list(APPEND mbed_storage_libs)
+
+if("DATAFLASH" IN_LIST MBED_TARGET_LABELS)
+    list(APPEND mbed_storage_libs mbed-storage-dataflash)
+endif()
+
+if("FLASHIAP" IN_LIST MBED_TARGET_LABELS)
+    list(APPEND mbed_storage_libs mbed-storage-flashiap)
+endif()
+
+if("I2CEE" IN_LIST MBED_TARGET_LABELS)
+    list(APPEND mbed_storage_libs mbed-storage-i2cee)
+endif()
+
+if("QSPIF" IN_LIST MBED_TARGET_LABELS)
+    list(APPEND mbed_storage_libs mbed-storage-qspif)
+endif()
+
+if("OSPIF" IN_LIST MBED_TARGET_LABELS)
+    list(APPEND mbed_storage_libs mbed-storage-ospif)
+endif()
+
+if("SD" IN_LIST MBED_TARGET_LABELS)
+    list(APPEND mbed_storage_libs mbed-storage-sd)
+endif()
+
+if("SPIF" IN_LIST MBED_TARGET_LABELS)
+    list(APPEND mbed_storage_libs mbed-storage-spif)
+endif()
+
 target_link_libraries(${APP_TARGET}
     PRIVATE
         mbed-os

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,12 +38,12 @@ if("I2CEE" IN_LIST MBED_TARGET_LABELS)
     list(APPEND mbed_storage_libs mbed-storage-i2cee)
 endif()
 
-if("QSPIF" IN_LIST MBED_TARGET_LABELS)
-    list(APPEND mbed_storage_libs mbed-storage-qspif)
-endif()
-
 if("OSPIF" IN_LIST MBED_TARGET_LABELS)
     list(APPEND mbed_storage_libs mbed-storage-ospif)
+endif()
+
+if("QSPIF" IN_LIST MBED_TARGET_LABELS)
+    list(APPEND mbed_storage_libs mbed-storage-qspif)
 endif()
 
 if("SD" IN_LIST MBED_TARGET_LABELS)
@@ -57,10 +57,8 @@ endif()
 target_link_libraries(${APP_TARGET}
     PRIVATE
         mbed-os
-        mbed-events
         mbed-storage
-        mbed-storage-qspif
-        mbed-storage-flashiap
+        ${mbed_storage_libs}
 )
 
 mbed_set_post_build(${APP_TARGET})

--- a/main.cpp
+++ b/main.cpp
@@ -20,30 +20,32 @@
 // Block devices
 #if COMPONENT_QSPIF
 #include "QSPIFBlockDevice.h"
+QSPIFBlockDevice bd;
+#endif
+
+#if COMPONENT_OSPIF
+#include "OSPIFBlockDevice.h"
+OSPIFBlockDevice bd;
 #endif
 
 #if COMPONENT_SPIF
 #include "SPIFBlockDevice.h"
+// Physical block device, can be any device that supports the BlockDevice API
+SPIFBlockDevice bd;
 #endif
 
 #if COMPONENT_DATAFLASH
 #include "DataFlashBlockDevice.h"
-#endif 
+DataFlashBlockDevice bd;
+#endif
 
 #if COMPONENT_SD
 #include "SDBlockDevice.h"
-#endif 
+// Physical block device, can be any device that supports the BlockDevice API
+SDBlockDevice bd;
+#endif
 
 #include "HeapBlockDevice.h"
-
-
-// Physical block device, can be any device that supports the BlockDevice API
-SDBlockDevice bd(
-        MBED_CONF_SD_SPI_MOSI,
-        MBED_CONF_SD_SPI_MISO,
-        MBED_CONF_SD_SPI_CLK,
-        MBED_CONF_SD_SPI_CS);
-
 
 // Entry point for the example
 int main() {


### PR DESCRIPTION
Mbed OS now handles the dependencies.

Depends on https://github.com/ARMmbed/mbed-os/pull/14078 for OSPIF support.