### PR TITLE
Fix and simplify BlockDevice selection

### DIFF
--- a/tests/blockdevice.log
+++ b/tests/blockdevice.log
@@ -1,26 +1,28 @@
 --- Mbed OS block device example ---
-bd.init\(\)
-bd.init -> 0
+bd->init\(\)
+bd->init -> 0
+bd->get_type\(\)
+bd->get_type -> .+
 --- Block device geometry ---
 read_size:\s+\d+ B
 program_size:\s+\d+ B
 erase_size:\s+\d+ B
 size:\s+\d+ B
 ---
-bd.read\((0x)?[0-9a-fA-F]+, \d+, \d+\)
-bd.read -> 0
+bd->read\((0x)?[0-9a-fA-F]+, \d+, \d+\)
+bd->read -> 0
 --- Stored data ---
 ([0-9a-fA-F]+\s+){15}[0-9a-fA-F]+
 ---
-bd.erase\(\d+, \d+\)
-bd.erase -> 0
-bd.program\((0x)?[0-9a-fA-F]+, \d+, \d+\)
-bd.program -> 0
-bd.read\((0x)?[0-9a-fA-F]+, \d+, \d+\)
-bd.read -> 0
+bd->erase\(\d+, \d+\)
+bd->erase -> 0
+bd->program\((0x)?[0-9a-fA-F]+, \d+, \d+\)
+bd->program -> 0
+bd->read\((0x)?[0-9a-fA-F]+, \d+, \d+\)
+bd->read -> 0
 --- Stored data ---
 ([0-9a-fA-F]+\s+){15}[0-9a-fA-F]+
 ---
-bd.deinit\(\)
-bd.deinit -> 0
+bd->deinit\(\)
+bd->deinit -> 0
 --- done! ---


### PR DESCRIPTION
This example goes through possible types of block devices one by one, and it has several issues:
* If a target has multiple block devices, the last one checked is used rather than the default instance defined by Mbed OS.
* A check for FlashIAP is missing, making this example fail to compile on several FlashIAP targets. This just reflects the impracticality of maintaining a hardcoded list.
* The header HeapBlockDevice.h is included but not actually used, so a fallback option is lacking for targets without a hardware block device.

To solve the above and simplify this example,
* Use the static member function `BlockDevice::get_default_instance()` to get the default block device, then use `BlockDevice::get_type()` to let users know the actual type.
* If no default block device is available, create a HeapBlockDevice instance to continue this example.